### PR TITLE
Programmatic editing of some doubles

### DIFF
--- a/src/ConfigEditor.cpp
+++ b/src/ConfigEditor.cpp
@@ -156,3 +156,9 @@ void ConfigEditor::update() {
    }
 
 }
+
+void ConfigEditor::putProgDouble(std::string key, double value) {
+   if(!key.find("prog")==0) {
+      Preferences::GetInstance()->PutDouble(key, value);
+   }
+}

--- a/src/ConfigEditor.h
+++ b/src/ConfigEditor.h
@@ -24,6 +24,8 @@ public:
    float getFloat(std::string key);
    double getDouble(std::string key);
    std::string getString(std::string key);
+
+   void putProgDouble(std::string key, double value);
 private:
    DriveStation* m_DriveStation;
 };


### PR DESCRIPTION
This is a pull request that adds the functionality within the Config Editor class to edit specific double variables within the preferences file. The only variables that remain editable are doubles that are prefixed by the string "prog" in all lowercase letters.

If this is not desirable functionality, please discuss with Frederick as he was the one who told me to add it.
